### PR TITLE
Upgrade devise to 4.6.0 closes #44

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'capistrano-rails', group: :development
 
 # User authentication
-gem 'devise'
+gem 'devise', '>= 4.6.0'
 gem 'devise-jwt'
 
 # User authorization

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
     crass (1.0.4)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (4.4.3)
+    devise (4.6.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 6.0)
@@ -244,9 +244,9 @@ GEM
       parser (>= 2.5.0.0, < 2.6)
       rainbow (>= 2.0, < 4.0)
     remotipart (1.4.2)
-    responders (2.4.0)
-      actionpack (>= 4.2.0, < 5.3)
-      railties (>= 4.2.0, < 5.3)
+    responders (2.4.1)
+      actionpack (>= 4.2.0, < 6.0)
+      railties (>= 4.2.0, < 6.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -333,8 +333,8 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    warden (1.2.7)
-      rack (>= 1.0)
+    warden (1.2.8)
+      rack (>= 2.0.6)
     warden-jwt_auth (0.3.5)
       dry-auto_inject (~> 0.4)
       dry-configurable (~> 0.5)
@@ -358,7 +358,7 @@ DEPENDENCIES
   cancancan
   coffee-rails (~> 4.2)
   coveralls
-  devise
+  devise (>= 4.6.0)
   devise-jwt
   factory_bot_rails
   faker


### PR DESCRIPTION
### Issues solved with this PR

- [Upgrade devise to 4.6.0 to deal with vulnerabilities](https://github.com/fblupi/echaequipos-backend/issues/44)