### PR TITLE
Fix travis.yml ruby version closes #46

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.5.1
+  - 2.6.2
 services:
   - mysql
 before_install:


### PR DESCRIPTION
### Issues solved with this PR

- [Fix travis.yml ruby version](https://github.com/fblupi/echaequipos-backend/issues/46)